### PR TITLE
Fix memory and copy errors

### DIFF
--- a/src/Network.cpp
+++ b/src/Network.cpp
@@ -89,12 +89,12 @@ Network::Network() {
 Network::~Network() {
 
 	// remove Ensembles (from last to first)
-	if (ensembles.size()>0) {
-	  for (unsigned int i=ensembles.size()-1; i > 0; i--)
-	  {
-		  remove_ensemble( ensembles[i] );
-	  }
-	}
+        if (!ensembles.empty()) {
+          for (int i = static_cast<int>(ensembles.size()) - 1; i >= 0; --i)
+          {
+                  remove_ensemble( ensembles[i] );
+          }
+        }
 
 	// remove remaining Nodes that were not part of ensembles
 
@@ -1589,14 +1589,14 @@ void Network::remove_ensemble(Ensemble* ensemble)
 	}
 
 	// delete Ensemble && Ensemble entry in Network
-	for (unsigned int i=0; i < ensembles.size(); i++) {
-		if (ensembles[i] == ensemble) {
-			//cout << "ensemble #" << i << endl;
-			ensembles.erase(ensembles.begin()+i);
-			delete ensembles[i]; //TODO BUG remove ensemble somewhere?!
-			break;
-		}
-	}
+        for (unsigned int i=0; i < ensembles.size(); i++) {
+                if (ensembles[i] == ensemble) {
+                        Ensemble* to_delete = ensembles[i];
+                        ensembles.erase(ensembles.begin()+i);
+                        delete to_delete;
+                        break;
+                }
+        }
 }
 
 

--- a/src/Sequence.cpp
+++ b/src/Sequence.cpp
@@ -69,9 +69,9 @@ bool Sequence::load_from_file(string filename)
 		if (v == NULL) continue;
 		read_line_as_vector(&ifs, v);
 
-		vector<weight_t>* v2 = new vector<weight_t>();
-		for (unsigned int i=0; i < v2->size(); i++)
-			v2->push_back( (*v)[i] );
+                vector<weight_t>* v2 = new vector<weight_t>();
+                for (unsigned int i=0; i < v->size(); i++)
+                        v2->push_back( (*v)[i] );
 
 		this->add(v,v2);
 		count++;

--- a/src/SequenceSet.cpp
+++ b/src/SequenceSet.cpp
@@ -47,32 +47,28 @@ SequenceSet::SequenceSet(SequenceSet &sequence_set)
 	{
 		set.push_back( sequence_set.set[i] );
 	}*/
-	this->set = sequence_set.set;
+        this->set = sequence_set.set;
 
 	name = sequence_set.name;
 
 	input_is_normalized = sequence_set.input_is_normalized;
 	target_is_normalized = sequence_set.target_is_normalized;
 
-	if (sequence_set.target_means != NULL) {
-		target_means = new std::vector<weight_t>();
-		copy( sequence_set.target_means->begin(),sequence_set.target_means->end(),target_means->begin() );
-	}
-	if (sequence_set.target_stds!= NULL) {
-		target_stds = new std::vector<weight_t>();
-		copy( sequence_set.target_stds->begin(),sequence_set.target_stds->end(),target_stds->begin() );
+        if (sequence_set.target_means != NULL) {
+                target_means = new std::vector<weight_t>( *sequence_set.target_means );
+        }
+        if (sequence_set.target_stds!= NULL) {
+                target_stds = new std::vector<weight_t>( *sequence_set.target_stds );
 
-	}
-	if (sequence_set.input_means != NULL) {
-		input_means = new std::vector<weight_t>();
-		copy( sequence_set.input_means->begin(),sequence_set.input_means->end(),input_means->begin() );
+        }
+        if (sequence_set.input_means != NULL) {
+                input_means = new std::vector<weight_t>( *sequence_set.input_means );
 
-	}
-	if (sequence_set.input_stds != NULL) {
-		input_stds = new std::vector<weight_t>();
-		copy( sequence_set.input_stds->begin(),sequence_set.input_stds->end(),input_stds->begin() );
+        }
+        if (sequence_set.input_stds != NULL) {
+                input_stds = new std::vector<weight_t>( *sequence_set.input_stds );
 
-	}
+        }
 
 	//TODO/BUG fill this vectors
 
@@ -134,10 +130,10 @@ SequenceSet::~SequenceSet()
 	}
 
 
-	/*for (unsigned int i=0; i < set.size(); i++)
-	{
-		delete set[i];
-	}*/
+        for (unsigned int i=0; i < set.size(); i++)
+        {
+                delete set[i];
+        }
 
 }
 


### PR DESCRIPTION
## Summary
- delete all ensembles when a `Network` is destroyed
- properly delete ensemble objects when removing them
- deep copy normalization vectors in `SequenceSet` copy constructor
- deallocate sequences in `SequenceSet` destructor
- fix loop in `Sequence::load_from_file`

## Testing
- `make gpp` *(fails: requires C++11 toolchain)*
- `make test` *(fails: Rscript not found)*

------
https://chatgpt.com/codex/tasks/task_e_6873deccecdc832c98c38f6d083f50ba